### PR TITLE
Add fields to notification.proto

### DIFF
--- a/proto/n0core/lib/proto/enums/request_status.proto
+++ b/proto/n0core/lib/proto/enums/request_status.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+enum RequestStatus {
+  INITIAL = 0;
+  PENDING = 1;
+  FAILED = 2;
+  SUCCESS = 3;
+}

--- a/proto/n0core/lib/proto/enums/request_status.proto
+++ b/proto/n0core/lib/proto/enums/request_status.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 enum RequestStatus {
-  INITIAL = 0;
-  PENDING = 1;
-  FAILED = 2;
+  AWAITING = 0;
+  PROCESSING = 1;
+  FAILURE = 2;
   SUCCESS = 3;
 }

--- a/proto/n0core/lib/proto/notification.proto
+++ b/proto/n0core/lib/proto/notification.proto
@@ -1,5 +1,9 @@
 syntax = "proto3";
 
+import "n0core/lib/proto/enums/request_status.proto";
+
 message Notification {
   string type = 1;
+  RequestStatus RequestStatus = 2;
+  string reason = 3;
 }


### PR DESCRIPTION
Add common notification fields.

I think below:
`Request` is just an abstract message type, because each message has each different parameters.
But `Notification` often needs nothing but it's status, so just `Notification` class is used to notify something.